### PR TITLE
Add support for lib_rtos_support CMake building

### DIFF
--- a/lib_xcore_c/api/xcore_c.h
+++ b/lib_xcore_c/api/xcore_c.h
@@ -7,13 +7,18 @@
 #include "xcore_c_channel.h"
 #include "xcore_c_channel_streaming.h"
 #include "xcore_c_channel_transaction.h"
+#if USE_XCORE_CLOCK_TYPE
 #include "xcore_c_clock.h"
+#endif
 #include "xcore_c_error_codes.h"
 #include "xcore_c_hwtimer.h"
 #include "xcore_c_interrupt.h"
 #include "xcore_c_lock.h"
 #include "xcore_c_port.h"
+#if USE_XCORE_CLOCK_TYPE
 #include "xcore_c_port_protocol.h"
+#endif
 #include "xcore_c_select.h"
 
 #endif // __xcore_c_h__
+

--- a/lib_xcore_c/api/xcore_c_port.h
+++ b/lib_xcore_c/api/xcore_c_port.h
@@ -214,10 +214,12 @@ inline xcore_c_error_t port_set_unbuffered(port p)
  *                                    or clock is running.
  *  \exception  ET_RESOURCE_DEP       another core is actively changing the port.
  */
+#if USE_XCORE_CLOCK_TYPE
 inline xcore_c_error_t port_set_clock(port p, clock clk)
 {
   RETURN_EXCEPTION_OR_ERROR( _port_set_clock(p, clk) );
 }
+#endif
 
 /** Set a port drive out the data value (default state).
  *
@@ -1081,3 +1083,4 @@ inline xcore_c_error_t port_disable_trigger(port p)
 #endif // !defined(__XC__)
 
 #endif // __xcore_c_port_h__
+

--- a/lib_xcore_c/src/xcore_c_interrupt.S
+++ b/lib_xcore_c/src/xcore_c_interrupt.S
@@ -9,6 +9,9 @@
 .globl _xcore_c_interrupt_permitted_common
 .align 2  // We arrive in single issue mode.
 .type  _xcore_c_interrupt_permitted_common,@function
+#ifdef __XS2A__
+.issue_mode single
+#endif
 .cc_top _xcore_c_interrupt_permitted_common.function,_xcore_c_interrupt_permitted_common
 _xcore_c_interrupt_permitted_common:
   // This is the body of the _xcore_c_interrupt_permitted_XXX functions.
@@ -69,6 +72,9 @@ _xcore_c_interrupt_permitted_common:
 .globl _xcore_c_interrupt_callback_common
 .align 2  // We arrive in single issue mode.
 .type  _xcore_c_interrupt_callback_common,@function
+#ifdef __XS2A__
+.issue_mode single
+#endif
 .cc_top _xcore_c_interrupt_callback_common.function,_xcore_c_interrupt_callback_common
 _xcore_c_interrupt_callback_common:
   // This is the body of the _xcore_c_interrupt_callback_XXX functions.

--- a/lib_xcore_c/src/xcore_c_interrupt_impl.h
+++ b/lib_xcore_c/src/xcore_c_interrupt_impl.h
@@ -14,6 +14,12 @@
 #define XCORE_C_KSTACK_WORDS 0
 #endif
 
+#ifdef __XS2A__
+# define ISSUE_MODE_SINGLE .issue_mode single
+#else
+# define ISSUE_MODE_SINGLE
+#endif
+
 #define _INTERRUPT_PERMITTED(root_function) \
     _xcore_c_interrupt_permitted_ ## root_function
 
@@ -29,6 +35,7 @@
     .globl _INTERRUPT_PERMITTED(root_function); \
     .align _XCORE_C_CODE_ALIGNMENT; \
     .type  _INTERRUPT_PERMITTED(root_function),@function; \
+    ISSUE_MODE_SINGLE; \
     .cc_top _INTERRUPT_PERMITTED(root_function).function,_INTERRUPT_PERMITTED(root_function); \
     _INTERRUPT_PERMITTED(root_function):; \
       _XCORE_C_ENTSP(_XCORE_C_STACK_ALIGN(3)); \
@@ -69,6 +76,7 @@
     .globl _INTERRUPT_CALLBACK(intrpt); \
     .align _XCORE_C_CODE_ALIGNMENT; \
     .type  _INTERRUPT_CALLBACK(intrpt),@function; \
+    ISSUE_MODE_SINGLE; \
     .cc_top _INTERRUPT_CALLBACK(intrpt).function,_INTERRUPT_CALLBACK(intrpt); \
     _INTERRUPT_CALLBACK(intrpt):; \
       _XCORE_C_SINGLE_ISSUE /* Do we know what KEDI is set to? */; \

--- a/lib_xcore_c/src/xcore_c_port.c
+++ b/lib_xcore_c/src/xcore_c_port.c
@@ -8,7 +8,9 @@ extern void _port_reset(port p);
 extern void _port_free(port p);
 extern void _port_set_buffered(port p);
 extern void _port_set_unbuffered(port p);
+#if USE_XCORE_CLOCK_TYPE
 extern void _port_set_clock(port p, clock clk);
+#endif
 extern void _port_set_inout_data(port p);
 extern void _port_set_out_clock(port p);
 extern void _port_set_out_ready(port p, port ready_source);
@@ -43,7 +45,9 @@ extern xcore_c_error_t port_free(port *p);
 extern xcore_c_error_t port_set_transfer_width(port p, size_t transfer_width);
 extern xcore_c_error_t port_set_buffered(port p);
 extern xcore_c_error_t port_set_unbuffered(port p);
+#if USE_XCORE_CLOCK_TYPE
 extern xcore_c_error_t port_set_clock(port p, clock clk);
+#endif
 extern xcore_c_error_t port_set_inout_data(port p);
 extern xcore_c_error_t port_set_out_clock(port p);
 extern xcore_c_error_t port_set_out_ready(port p, port ready_source);
@@ -84,6 +88,7 @@ extern xcore_c_error_t port_setup_interrupt_callback(port p, void *data, interru
 extern xcore_c_error_t port_enable_trigger(port p);
 extern xcore_c_error_t port_disable_trigger(port p);
 
+#if USE_XCORE_CLOCK_TYPE
 #include "xcore_c_port_protocol.h"
 extern xcore_c_error_t port_protocol_in_handshake(port p, port readyin, port readyout, clock clk);
 extern xcore_c_error_t port_protocol_out_handshake(port p, port readyin, port readyout, clock clk, uint32_t initial);
@@ -91,3 +96,4 @@ extern xcore_c_error_t port_protocol_in_strobed_master(port p, port readyout, cl
 extern xcore_c_error_t port_protocol_out_strobed_master(port p, port readyout, clock clk, uint32_t initial);
 extern xcore_c_error_t port_protocol_in_strobed_slave(port p, port readyin, clock clk);
 extern xcore_c_error_t port_protocol_out_strobed_slave(port p, port readyin, clock clk, uint32_t initial);
+#endif

--- a/lib_xcore_c/src/xcore_c_port_impl.h
+++ b/lib_xcore_c/src/xcore_c_port_impl.h
@@ -56,10 +56,12 @@ inline void _port_set_unbuffered(port p)
   _RESOURCE_SETCI(p, XS1_SETC_BUF_NOBUFFERS);
 }
 
+#if USE_XCORE_CLOCK_TYPE
 inline void _port_set_clock(port p, clock clk)
 {
   asm volatile("setclk res[%0], %1" :: "r" (p), "r" (clk));
 }
+#endif
 
 inline void _port_set_inout_data(port p)
 {

--- a/lib_xcore_c/src/xcore_c_select_impl.h
+++ b/lib_xcore_c/src/xcore_c_select_impl.h
@@ -14,8 +14,10 @@
 // _SELECT_CALLBACK_STACK_SIZE also defined in xcore_c_select.S
 #ifdef __XS2A__
 # define _SELECT_CALLBACK_STACK_SIZE  2
+# define ISSUE_MODE_SINGLE .issue_mode single
 #else
 # define _SELECT_CALLBACK_STACK_SIZE  1
+# define ISSUE_MODE_SINGLE
 #endif
 
 #define _SELECT_CALLBACK(callback) \
@@ -30,6 +32,7 @@
     .globl _SELECT_CALLBACK(callback); \
     .align _XCORE_C_CODE_ALIGNMENT; \
     .type  _SELECT_CALLBACK(callback),@function; \
+    ISSUE_MODE_SINGLE; \
     .cc_top _SELECT_CALLBACK(callback).function,_SELECT_CALLBACK(callback); \
     _SELECT_CALLBACK(callback):; \
       _XCORE_C_ENTSP( _SELECT_CALLBACK_STACK_SIZE ); \


### PR DESCRIPTION
Add CMakeLists.txt

Add wrappers around instances of XMOS declared clock to resolve
collisions with files that include time.h and FreeRTOS.h.